### PR TITLE
Gjør det vanskeligere å lage ugyldig testdata

### DIFF
--- a/saksbehandlingsstatistikk/src/main/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/GodkjenningsBehovLøsningData.kt
+++ b/saksbehandlingsstatistikk/src/main/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/GodkjenningsBehovLøsningData.kt
@@ -18,10 +18,6 @@ data class GodkjenningsBehovLøsningData(
         .automatiskBehandling(automatiskBehandling)
         .resultat("AVVIST")
 
-    fun vedtaksperiodeId(it: UUID) = copy(vedtaksperiodeId = it)
-    fun saksbehandlerIdent(it: String) = copy(saksbehandlerIdent = it)
-    fun automatiskBehandling(it: Boolean) = copy(automatiskBehandling = it)
-
     companion object {
         fun fromJson(packet: JsonMessage) =
             GodkjenningsBehovLøsningData(

--- a/saksbehandlingsstatistikk/src/main/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/VedtakFattetData.kt
+++ b/saksbehandlingsstatistikk/src/main/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/VedtakFattetData.kt
@@ -13,8 +13,6 @@ data class VedtakFattetData(
     val avsluttetISpleis: LocalDateTime,
     val erAvsluttetUtenGodkjenning: Boolean
 ) {
-    fun hendelse(it: UUID) = copy(hendelser = hendelser + it)
-    fun vedtaksperiodeId(it: UUID) = copy(vedtaksperiodeId = it)
 
     fun anrik(søknad: Søknad) = søknad.vedtakFattet(avsluttetISpleis).resultat("INNVILGET")
         .let {

--- a/saksbehandlingsstatistikk/src/main/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/VedtaksperiodeAvvistData.kt
+++ b/saksbehandlingsstatistikk/src/main/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/VedtaksperiodeAvvistData.kt
@@ -12,15 +12,12 @@ data class VedtaksperiodeAvvistData(
     val vedtakFattet: LocalDateTime,
     val automatiskBehandling: Boolean,
 ) {
+
     fun anrik(søknad: Søknad) = søknad
         .saksbehandlerIdent(saksbehandlerIdent)
         .vedtakFattet(vedtakFattet)
         .automatiskBehandling(automatiskBehandling)
         .resultat("AVVIST")
-
-    fun vedtaksperiodeId(it: UUID) = copy(vedtaksperiodeId = it)
-    fun saksbehandlerIdent(it: String) = copy(saksbehandlerIdent = it)
-    fun automatiskBehandling(it: Boolean) = copy(automatiskBehandling = it)
 
     companion object {
         fun fromJson(packet: JsonMessage) =

--- a/saksbehandlingsstatistikk/src/main/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/VedtaksperiodeEndretData.kt
+++ b/saksbehandlingsstatistikk/src/main/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/VedtaksperiodeEndretData.kt
@@ -8,7 +8,6 @@ data class VedtaksperiodeEndretData(
     val hendelser: List<UUID>,
     val vedtaksperiodeId: UUID,
 ) {
-    fun hendelse(it: UUID) = copy(hendelser = hendelser + it)
 
     companion object {
         fun fromJson(packet: JsonMessage) = VedtaksperiodeEndretData(

--- a/saksbehandlingsstatistikk/src/main/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/VedtaksperiodeForkastetData.kt
+++ b/saksbehandlingsstatistikk/src/main/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/VedtaksperiodeForkastetData.kt
@@ -11,7 +11,6 @@ data class VedtaksperiodeForkastetData(
     val vedtaksperiodeForkastet: LocalDateTime,
     val aktørId: String
 ) {
-    fun vedtaksperiodeId(it: UUID) = copy(vedtaksperiodeId = it)
 
     fun anrik(søknad: Søknad) = søknad.vedtakFattet(vedtaksperiodeForkastet).resultat("AVVIST")
         .let {

--- a/saksbehandlingsstatistikk/src/main/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/VedtaksperiodeGodkjentData.kt
+++ b/saksbehandlingsstatistikk/src/main/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/VedtaksperiodeGodkjentData.kt
@@ -12,14 +12,13 @@ data class VedtaksperiodeGodkjentData(
     val vedtakFattet: LocalDateTime,
     val automatiskBehandling: Boolean,
 ) {
+
     fun anrik(søknad: Søknad) = søknad
         .saksbehandlerIdent(saksbehandlerIdent)
         .vedtakFattet(vedtakFattet)
         .automatiskBehandling(automatiskBehandling)
         .resultat("INNVILGET")
 
-    fun vedtaksperiodeId(it: UUID) = copy(vedtaksperiodeId = it)
-    fun saksbehandlerIdent(it: String) = copy(saksbehandlerIdent = it)
     fun automatiskBehandling(it: Boolean) = copy(automatiskBehandling = it)
 
     companion object {

--- a/saksbehandlingsstatistikk/src/test/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/EndToEndTest.kt
+++ b/saksbehandlingsstatistikk/src/test/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/EndToEndTest.kt
@@ -44,15 +44,18 @@ internal class EndToEndTest {
     fun `Innvilget av Spesialist eller menneske`() {
         val søknadData = søknadData()
 
-        val vedtaksperiodeEndret = vedtaksperiodeEndretData()
-            .hendelse(søknadData.hendelseId)
+        val vedtaksperiodeEndret = vedtaksperiodeEndretData(
+            hendelse = søknadData.hendelseId
+        )
 
-        val vedtaksperiodeGodkjent = vedtaksperiodeGodkjent()
-            .vedtaksperiodeId(vedtaksperiodeEndret.vedtaksperiodeId)
+        val vedtaksperiodeGodkjent = vedtaksperiodeGodkjent(
+            vedtaksperiodeId = vedtaksperiodeEndret.vedtaksperiodeId
+        )
 
-        val vedtakFattet = vedtakFattet()
-            .hendelse(søknadData.hendelseId)
-            .vedtaksperiodeId(vedtaksperiodeEndret.vedtaksperiodeId)
+        val vedtakFattet = vedtakFattet(
+            hendelse = søknadData.hendelseId,
+            vedtaksperiodeId = vedtaksperiodeEndret.vedtaksperiodeId
+        )
 
         testRapid.sendTestMessage(søknadData.json())
         testRapid.sendTestMessage(vedtaksperiodeEndret.json())
@@ -82,9 +85,10 @@ internal class EndToEndTest {
     fun `Innvilget av spleis`() {
         val søknadData = søknadData()
 
-        val vedtakFattet = vedtakFattet()
-            .hendelse(søknadData.hendelseId)
-            .vedtaksperiodeId(UUID.randomUUID())
+        val vedtakFattet = vedtakFattet(
+            hendelse = søknadData.hendelseId,
+            vedtaksperiodeId = UUID.randomUUID()
+        )
 
         testRapid.sendTestMessage(søknadData.json())
         testRapid.sendTestMessage(vedtakFattet.jsonAvsluttetUtenGodkjenning)
@@ -112,10 +116,13 @@ internal class EndToEndTest {
     fun `Avvist av spleis`() {
         val søknadData = søknadData()
 
-        val vedtaksperiodeEndret = vedtaksperiodeEndretData()
-            .hendelse(søknadData.hendelseId)
+        val vedtaksperiodeEndret = vedtaksperiodeEndretData(
+            hendelse = søknadData.hendelseId
+        )
 
-        val vedtaksperiodeForkastet = vedtaksperiodeForkastet().vedtaksperiodeId(vedtaksperiodeEndret.vedtaksperiodeId)
+        val vedtaksperiodeForkastet = vedtaksperiodeForkastet(
+            vedtaksperiodeId = vedtaksperiodeEndret.vedtaksperiodeId
+        )
 
         testRapid.sendTestMessage(søknadData.json())
         testRapid.sendTestMessage(vedtaksperiodeEndret.json())
@@ -144,13 +151,17 @@ internal class EndToEndTest {
     fun `Avvist av spesialist eller menneske`() {
         val søknadData = søknadData()
 
-        val vedtaksperiodeEndret = vedtaksperiodeEndretData()
-            .hendelse(søknadData.hendelseId)
+        val vedtaksperiodeEndret = vedtaksperiodeEndretData(
+            hendelse = søknadData.hendelseId
+        )
 
-        val vedtaksperiodeAvvist = vedtaksperiodeAvvist()
-            .vedtaksperiodeId(vedtaksperiodeEndret.vedtaksperiodeId)
+        val vedtaksperiodeAvvist = vedtaksperiodeAvvist(
+            vedtaksperiodeId = vedtaksperiodeEndret.vedtaksperiodeId
+        )
 
-        val vedtaksperiodeForkastet = vedtaksperiodeForkastet().vedtaksperiodeId(vedtaksperiodeEndret.vedtaksperiodeId)
+        val vedtaksperiodeForkastet = vedtaksperiodeForkastet(
+            vedtaksperiodeId = vedtaksperiodeEndret.vedtaksperiodeId
+        )
 
 
         testRapid.sendTestMessage(søknadData.json())
@@ -181,13 +192,17 @@ internal class EndToEndTest {
     fun `Avvist av spesialist eller menneske før avvist event`() {
         val søknadData = søknadData()
 
-        val vedtaksperiodeEndret = vedtaksperiodeEndretData()
-            .hendelse(søknadData.hendelseId)
+        val vedtaksperiodeEndret = vedtaksperiodeEndretData(
+            hendelse = søknadData.hendelseId
+        )
 
-        val ikkegodkjentBehovsLøsning = ikkeGodkjentGodkjenningBehovsLøsning()
-            .vedtaksperiodeId(vedtaksperiodeEndret.vedtaksperiodeId)
+        val ikkegodkjentBehovsLøsning = ikkeGodkjentGodkjenningBehovsLøsning(
+            vedtaksperiodeId = vedtaksperiodeEndret.vedtaksperiodeId
+        )
 
-        val vedtaksperiodeForkastet = vedtaksperiodeForkastet().vedtaksperiodeId(vedtaksperiodeEndret.vedtaksperiodeId)
+        val vedtaksperiodeForkastet = vedtaksperiodeForkastet(
+            vedtaksperiodeId = vedtaksperiodeEndret.vedtaksperiodeId
+        )
 
         testRapid.sendTestMessage(søknadData.json())
         testRapid.sendTestMessage(vedtaksperiodeEndret.json())

--- a/saksbehandlingsstatistikk/src/test/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/TestData.kt
+++ b/saksbehandlingsstatistikk/src/test/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/TestData.kt
@@ -5,7 +5,11 @@ import java.time.temporal.ChronoUnit
 import java.util.*
 
 object TestData {
-    fun vedtaksperiodeEndretData() = VedtaksperiodeEndretData(listOf(), UUID.randomUUID())
+
+    fun vedtaksperiodeEndretData(hendelse: UUID) = VedtaksperiodeEndretData(
+        listOf(hendelse),
+        UUID.randomUUID()
+    )
 
     fun søknadData() = SøknadData(
         UUID.randomUUID(),
@@ -13,8 +17,8 @@ object TestData {
         LocalDateTime.now().minusDays(2).truncatedTo(ChronoUnit.MILLIS),
     )
 
-    fun vedtaksperiodeGodkjent() = VedtaksperiodeGodkjentData(
-        UUID.randomUUID(),
+    fun vedtaksperiodeGodkjent(vedtaksperiodeId: UUID) = VedtaksperiodeGodkjentData(
+        vedtaksperiodeId,
         randomIndent(),
         LocalDateTime.now().minusDays(1).truncatedTo(ChronoUnit.MILLIS),
         true
@@ -22,29 +26,29 @@ object TestData {
 
     private fun randomIndent() = "${randomString(('A'..'Z'), 1)}${randomString(('0'..'9'), 6)}"
 
-    fun vedtakFattet() = VedtakFattetData(
+    fun vedtakFattet(hendelse: UUID, vedtaksperiodeId: UUID) = VedtakFattetData(
         randomIndent(),
-        emptyList(),
-        UUID.randomUUID(),
+        listOf(hendelse),
+        vedtaksperiodeId,
         LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS),
         false
     )
 
-    fun vedtaksperiodeForkastet() = VedtaksperiodeForkastetData(
-        UUID.randomUUID(),
+    fun vedtaksperiodeForkastet(vedtaksperiodeId: UUID) = VedtaksperiodeForkastetData(
+        vedtaksperiodeId,
         LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS),
         randomIndent(),
     )
 
-    fun vedtaksperiodeAvvist() = VedtaksperiodeAvvistData(
-        UUID.randomUUID(),
+    fun vedtaksperiodeAvvist(vedtaksperiodeId: UUID) = VedtaksperiodeAvvistData(
+        vedtaksperiodeId,
         randomIndent(),
         LocalDateTime.now().minusDays(1).truncatedTo(ChronoUnit.MILLIS),
         true
     )
 
-    fun ikkeGodkjentGodkjenningBehovsLøsning() = GodkjenningsBehovLøsningData(
-        UUID.randomUUID(),
+    fun ikkeGodkjentGodkjenningBehovsLøsning(vedtaksperiodeId: UUID) = GodkjenningsBehovLøsningData(
+        vedtaksperiodeId,
         randomIndent(),
         LocalDateTime.now().minusDays(1).truncatedTo(ChronoUnit.MILLIS),
         true,

--- a/saksbehandlingsstatistikk/src/test/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/TilstandTest.kt
+++ b/saksbehandlingsstatistikk/src/test/kotlin/no/nav/helse/spre/saksbehandlingsstatistikk/TilstandTest.kt
@@ -60,11 +60,13 @@ internal class TilstandTest {
     fun `lagrer saksbehandlingsløp for automatisk behandlet søknad`() {
         val søknadData = søknadData()
 
-        val vedtaksperiodeEndret = vedtaksperiodeEndretData()
-            .hendelse(søknadData.hendelseId)
+        val vedtaksperiodeEndret = vedtaksperiodeEndretData(
+            hendelse = søknadData.hendelseId
+        )
 
-        val vedtaksperiodeGodkjent = vedtaksperiodeGodkjent()
-            .vedtaksperiodeId(vedtaksperiodeEndret.vedtaksperiodeId)
+        val vedtaksperiodeGodkjent = vedtaksperiodeGodkjent(
+            vedtaksperiodeId = vedtaksperiodeEndret.vedtaksperiodeId
+        )
 
         val expected = søknadData.asSøknad
             .saksbehandlerIdent(vedtaksperiodeGodkjent.saksbehandlerIdent)
@@ -94,12 +96,13 @@ internal class TilstandTest {
     fun `lagrer saksbehandlingsløp for manuelt behandlet søknad`() {
         val søknadData = søknadData()
 
-        val vedtaksperiodeEndret = vedtaksperiodeEndretData()
-            .hendelse(søknadData.hendelseId)
+        val vedtaksperiodeEndret = vedtaksperiodeEndretData(
+            hendelse = søknadData.hendelseId
+        )
 
-        val vedtaksperiodeGodkjent = vedtaksperiodeGodkjent()
-            .vedtaksperiodeId(vedtaksperiodeEndret.vedtaksperiodeId)
-            .automatiskBehandling(false)
+        val vedtaksperiodeGodkjent = vedtaksperiodeGodkjent(
+            vedtaksperiodeId = vedtaksperiodeEndret.vedtaksperiodeId
+        ).automatiskBehandling(false)
 
         val expected = søknadData.asSøknad
             .saksbehandlerIdent(vedtaksperiodeGodkjent.saksbehandlerIdent)


### PR DESCRIPTION
Ved å gjøre felter som alltid vil finnes i eventene påkrevde i
testdatafunksjonene fjernes muligheten for å lage testdata som mangler
felter - eksempelvis kan man ikke lenger lage vedtak_fattet som mangler
hendelser-listen.